### PR TITLE
Fix failing and nondeterministic unit tests outcomes.

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -49,7 +49,7 @@ impl Loader {
 
         let num_triangles = (floats.len()/12) as u32;
         let num_threads = if let Some(max_workers) = self.max_workers {
-            max_workers.max(thread::available_parallelism().expect("Could not query number of cores").get()) as u32
+            max_workers.min(thread::available_parallelism().expect("Could not query number of cores").get()) as u32
         } else {
             thread::available_parallelism().expect("Could not query number of cores").get() as u32
         };
@@ -124,7 +124,7 @@ impl Loader {
 
         //TODO: enable multithreading
         let num_threads = if let Some(max_workers) = self.max_workers {
-            max_workers.max(thread::available_parallelism().expect("Could not query number of cores").get()) as u32
+            max_workers.min(thread::available_parallelism().expect("Could not query number of cores").get()) as u32
         } else {
             thread::available_parallelism().expect("Could not query number of cores").get() as u32
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn run(start_time: SystemTime, filename: Option<String>, event_loop: Event
     let instance = wgpu::Instance::new(wgpu::Backends::all());
     let surface = unsafe { instance.create_surface(&window)};
     
-    let loader = Loader::new(filename.unwrap(), start_time);
+    let loader = Loader::new(filename.unwrap(), start_time, None);
     let data_future = tokio::spawn(
         async move {
             loader.run()            


### PR DESCRIPTION
The hashmaps used for vertex indexing are not shared between threads. In general, this keeps
inter-thread communication to a minimum and is ideal for large geometries, at the cost of
pessimizing very small geometries where each worker will only see a small amount of vertices.

The solution was to add an optional max number of threads to the loader which will override the
"available_parallelism" call.